### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/build-ios-and-android.yml
+++ b/.github/workflows/build-ios-and-android.yml
@@ -1,29 +1,45 @@
 name: Build Android & iOS
 
-# Triggered when code is pushed to the main branch
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test --ci
+
   build-ios:
+    needs: test
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - uses: actions/cache@v2
+          node-version: 18
+          cache: 'yarn'
+      - uses: actions/cache@v3
         with:
           path: ~/Library/Caches/CocoaPods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cocoapods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -45,24 +61,28 @@ jobs:
 
       # Upload the IPA file as an artifact
       - name: Upload IPA
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Ipa
           path: ios/build/*.ipa
 
   build-android:
+    needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin' # Install JDK from the Eclipse Temurin distribution
+          distribution: 'temurin'
           java-version: '17'
 
-      # Gradle Cache https://github.com/actions/cache/blob/main/examples.md#java---gradle
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -71,32 +91,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # Yarn Cache: https://github.com/actions/cache/blob/master/examples.md#node---yarn
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install node dependencies
-        run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
 
       - name: Bundle *.aap & *.apk
         run: cd android && ./gradlew bundleRelease assembleRelease
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Apk
           path: android/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Aab
           path: android/app/build/outputs/bundle/release/app-release.aab


### PR DESCRIPTION
## Summary
- improve build workflow
- run tests on PRs and pushes
- cache yarn and gradle with latest actions
- set up Node 18 and cancel in-progress runs
- upload artifacts with newer action versions

## Testing
- `yarn install` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*